### PR TITLE
Expose lock PID getter to public API

### DIFF
--- a/src/Lock.php
+++ b/src/Lock.php
@@ -177,7 +177,7 @@ class Lock
      *
      * @return string|false Will return the pid as a string or FALSE on failure.
      */
-    protected function readLockPid()
+    public function readLockPid()
     {
         $filename = sprintf("%s/%s.lock", $this->bucket, self::cleanName($this->name));
         $pid = @file_get_contents($filename);


### PR DESCRIPTION
- changed visibility of lock pid getter from protected to public to allow it to be read outside of the class
